### PR TITLE
Fix monitoring endpoints

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -11,11 +11,11 @@ sites:
     expectedStatusCodes:
       - 200
   - name: Prosper API (Production)
-    url: https://api.prosper.love/api/ping
+    url: https://api.prosper.codes/health
     expectedStatusCodes:
       - 200
-  - name: Prosper Website
-    url: https://prosper.love
+  - name: Prosper Admin (Production)
+    url: https://admin.prosper.codes
     expectedStatusCodes:
       - 200
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This repository contains the open-source uptime monitor and status page for [Pro
 | --- | ------ | ------- | ------------- | ------ |
 | [Prosper API (Staging)](https://stage.prosper.codes/health) | 🟩 Up | - | - | - |
 | [Prosper Admin (Staging)](https://admin-stage.prosper.codes/health) | 🟩 Up | - | - | - |
-| [Prosper API (Production)](https://api.prosper.love/api/ping) | 🟩 Up | - | - | - |
-| [Prosper Website](https://prosper.love) | 🟩 Up | - | - | - |
+| [Prosper API (Production)](https://api.prosper.codes/health) | 🟩 Up | - | - | - |
+| [Prosper Admin (Production)](https://admin.prosper.codes) | 🟩 Up | - | - | - |
 <!--end: status pages-->
 
 > This status page is powered by [Upptime](https://upptime.js.org).


### PR DESCRIPTION
## Summary
- Replace non-existent `api.prosper.love/api/ping` with `api.prosper.codes/health`
- Replace `prosper.love` with `admin.prosper.codes` (Admin Production)

## Updated endpoints
| Name | URL |
|------|-----|
| Prosper API (Staging) | `https://stage.prosper.codes/health` |
| Prosper Admin (Staging) | `https://admin-stage.prosper.codes/health` |
| Prosper API (Production) | `https://api.prosper.codes/health` |
| Prosper Admin (Production) | `https://admin.prosper.codes` |