### PR TITLE
Fix Setup CI to generate graphs inline

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -36,10 +36,11 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: benc-uk/workflow-dispatch@v1
+        uses: upptime/uptime-monitor@v1.41.0
         with:
-          workflow: Graphs CI
-          token: ${{ secrets.GH_PAT || github.token }}
+          command: "graphs"
+        env:
+          GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
         uses: upptime/uptime-monitor@v1.41.0
         with:


### PR DESCRIPTION
## Summary
- Replace `benc-uk/workflow-dispatch` (requires GH_PAT to trigger other workflows) with direct `upptime/uptime-monitor` graphs command
- Allows Setup CI to complete without GH_PAT secret

## Problem
Setup CI failed at "Generate graphs" step because `github.token` cannot trigger other workflows via `workflow_dispatch`.

## Fix
Run graphs generation inline in the same job instead of dispatching a separate workflow.