### PR TITLE
Update styling and fix admin endpoint

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -18,6 +18,8 @@ sites:
     url: https://admin.prosper.codes
     expectedStatusCodes:
       - 200
+      - 301
+      - 302
 
 status-website:
   cname: status.prosper.codes
@@ -27,8 +29,38 @@ status-website:
   navbar:
     - title: Status
       href: /
-    - title: GitHub
-      href: https://github.com/$OWNER/$REPO
+  css: |
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+    :root {
+      --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --color-primary: #0055fe;
+      --color-secondary: #4f1ad6;
+    }
+    body {
+      font-family: var(--font-family) !important;
+    }
+    * {
+      font-family: var(--font-family) !important;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--font-family) !important;
+    }
+    .status-up, .tag.is-success {
+      background-color: #dbfcbd !important;
+      color: #1a5c00 !important;
+    }
+    a {
+      color: #0055fe;
+    }
+    a:hover {
+      color: #4f1ad6;
+    }
+    .navbar-brand .navbar-item {
+      font-weight: 700;
+    }
+    footer, .footer {
+      display: none !important;
+    }
 
 workflowSchedule:
   uptime: "*/5 * * * *"

--- a/history/prosper-admin-production.yml
+++ b/history/prosper-admin-production.yml
@@ -1,7 +1,7 @@
 url: https://admin.prosper.codes
 status: up
 code: 200
-responseTime: 425
-lastUpdated: 2026-03-04T05:26:12.786Z
+responseTime: 138
+lastUpdated: 2026-03-04T05:33:50.445Z
 startTime: 2026-03-04T05:23:39.018Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-admin-staging.yml
+++ b/history/prosper-admin-staging.yml
@@ -1,7 +1,7 @@
 url: https://admin-stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 403
-lastUpdated: 2026-03-04T05:26:11.396Z
+responseTime: 398
+lastUpdated: 2026-03-04T05:33:49.492Z
 startTime: 2026-03-04T05:23:37.390Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-production.yml
+++ b/history/prosper-api-production.yml
@@ -1,7 +1,7 @@
 url: https://api.prosper.codes/health
 status: up
 code: 200
-responseTime: 597
-lastUpdated: 2026-03-04T05:26:12.176Z
+responseTime: 439
+lastUpdated: 2026-03-04T05:33:50.118Z
 startTime: 2026-03-04T05:23:38.102Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-staging.yml
+++ b/history/prosper-api-staging.yml
@@ -1,7 +1,7 @@
 url: https://stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 536
-lastUpdated: 2026-03-04T05:26:10.802Z
+responseTime: 653
+lastUpdated: 2026-03-04T05:33:48.900Z
 startTime: 2026-03-04T05:23:36.459Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary
- Remove GitHub link from status page navbar
- Hide "powered by Upptime" footer via CSS
- Apply Prosper brand: Inter font, `#0055fe` primary, `#4f1ad6` accent, `#dbfcbd` success green
- Accept 301/302 status codes for `admin.prosper.codes` (redirects to login page)

## Fixes
- Admin Production was showing as "Down" because it returns 302 redirect to login
- All services showed "Down" on first deploy — Uptime CI needs to run to populate data