### PR TITLE
Fix commit message format for status/response time

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -122,7 +122,7 @@ workflowSchedule:
 commitMessages:
   readmeContent: "Update summary in README [skip ci]"
   summaryJson: "Update status summary [skip ci]"
-  statusChange: "$SITE_NAME is $STATUS"
+  statusChange: "$EMOJI $SITE_NAME is $STATUS ($CODE in $RESPONSE_TIME ms)"
   graphsUpdate: "Update graphs [skip ci]"
   commitAuthorName: "Upptime Bot"
   commitAuthorEmail: "upptime@prosper.codes"


### PR DESCRIPTION
## Problem
All services show as "down" with 0ms response time despite being up.

## Root cause
Upptime's summary generator parses **commit messages** to determine status and response time:
- Status: looks for emoji prefix (`🟩` = up, `🟨` = degraded, other = down)
- Response time: parses `"in X ms"` from message

Our config had `statusChange: "$SITE_NAME is $STATUS"` — no emoji, no response time.

## Fix
Changed to: `"$EMOJI $SITE_NAME is $STATUS ($CODE in $RESPONSE_TIME ms)"`

This produces commits like: `🟩 Prosper API is up (200 in 321 ms)`