### PR TITLE
Fix status emoji in commit messages

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -122,7 +122,7 @@ workflowSchedule:
 commitMessages:
   readmeContent: "Update summary in README [skip ci]"
   summaryJson: "Update status summary [skip ci]"
-  statusChange: "$EMOJI $SITE_NAME is $STATUS ($CODE in $RESPONSE_TIME ms)"
+  statusChange: "$PREFIX $SITE_NAME is $STATUS ($RESPONSE_CODE in $RESPONSE_TIME ms)"
   graphsUpdate: "Update graphs [skip ci]"
   commitAuthorName: "Upptime Bot"
   commitAuthorEmail: "upptime@prosper.codes"


### PR DESCRIPTION
Use $PREFIX (not $EMOJI) and $RESPONSE_CODE (not $CODE) per Upptime source code.