### PR TITLE
Override night theme CSS variables for pure black design

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -24,12 +24,24 @@ sites:
 status-website:
   cname: status.prosper.codes
   name: Prosper Status
-  logoUrl: https://prosper.love/favicon.ico
   theme: night
   navbar:
     - title: Status
       href: /
   css: |
+    :root {
+      --body-background-color: #000000 !important;
+      --body-text-color: #e0e0e0 !important;
+      --card-background-color: #111111 !important;
+      --nav-background-color: #000000 !important;
+      --nav-border-bottom-color: rgba(255,255,255,0.08) !important;
+      --nav-current-border-bottom-color: #ffffff !important;
+      --card-border-color: rgba(255,255,255,0.06) !important;
+      --up-border-left-color: rgba(255,255,255,0.2) !important;
+      --tag-up-background-color: rgba(255,255,255,0.1) !important;
+      --tag-down-background-color: rgba(255,76,76,0.15) !important;
+      --graph-opacity: 0.8 !important;
+    }
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
     body, *, h1, h2, h3, h4, h5, h6, p, a, span, div, li, td, th, label, input, select, button, .title, .subtitle, .content, .navbar-item, .card-content, .card-content * {
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;

--- a/history/prosper-admin-production.yml
+++ b/history/prosper-admin-production.yml
@@ -1,7 +1,7 @@
 url: https://admin.prosper.codes
 status: up
 code: 200
-responseTime: 949
-lastUpdated: 2026-03-04T06:04:22.995Z
+responseTime: 218
+lastUpdated: 2026-03-04T06:11:52.899Z
 startTime: 2026-03-04T05:23:39.018Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-admin-staging.yml
+++ b/history/prosper-admin-staging.yml
@@ -1,7 +1,7 @@
 url: https://admin-stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 467
-lastUpdated: 2026-03-04T06:04:21.361Z
+responseTime: 876
+lastUpdated: 2026-03-04T06:11:51.864Z
 startTime: 2026-03-04T05:23:37.390Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-production.yml
+++ b/history/prosper-api-production.yml
@@ -1,7 +1,7 @@
 url: https://api.prosper.codes/health
 status: up
 code: 200
-responseTime: 358
-lastUpdated: 2026-03-04T06:04:21.885Z
+responseTime: 438
+lastUpdated: 2026-03-04T06:11:52.490Z
 startTime: 2026-03-04T05:23:38.102Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-staging.yml
+++ b/history/prosper-api-staging.yml
@@ -1,7 +1,7 @@
 url: https://stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 451
-lastUpdated: 2026-03-04T06:04:20.728Z
+responseTime: 313
+lastUpdated: 2026-03-04T06:11:50.792Z
 startTime: 2026-03-04T05:23:36.459Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary
- Override Upptime night theme `:root` CSS variables to use pure black (#000000) instead of green-tinted defaults (#0d1117)
- Variables overridden: `--body-background-color`, `--card-background-color`, `--nav-background-color`, `--card-border-color`, `--tag-up-background-color`, `--tag-down-background-color`, etc.
- Remove broken `logoUrl` (prosper.love/favicon.ico returns 404)
- This fixes the green/teal tint that persisted despite `!important` CSS overrides

## Test plan
- [ ] Merge and trigger Static Site CI workflow
- [ ] Verify status.prosper.codes has pure black background (no green tint)
- [ ] Verify cards are dark (#111) not green-gray (#30363D)
- [ ] Verify navbar has no green-tinted background