### PR TITLE
Add status labels, fallback renderer, fix graphs

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -172,64 +172,110 @@ status-website:
     .column {
       padding: 0.5rem !important;
     }
+    .fallback-container { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
+    .fallback-header { text-align: center; margin-bottom: 2.5rem; }
+    .fallback-header h1 { font-size: 2rem; font-weight: 700; color: #fff; margin-bottom: 0.25rem; }
+    .fallback-header p { color: rgba(255,255,255,0.4); font-size: 0.9rem; }
+    .fallback-summary { display: inline-flex; align-items: center; gap: 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.06); border-radius: 8px; padding: 0.5rem 1rem; margin-bottom: 2rem; }
+    .fallback-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .fallback-dot.up { background: #22c55e; box-shadow: 0 0 8px rgba(34,197,94,0.4); }
+    .fallback-dot.down { background: #ef4444; box-shadow: 0 0 8px rgba(239,68,68,0.4); }
+    .fallback-summary span { font-size: 0.85rem; color: rgba(255,255,255,0.7); }
+    .fb-card { background: #0a0a0a; border: 1px solid rgba(255,255,255,0.04); border-radius: 12px; padding: 1.25rem 1.5rem; margin-bottom: 0.75rem; display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+    .fb-card:hover { border-color: rgba(255,255,255,0.08); }
+    .fb-left { display: flex; align-items: center; gap: 1rem; min-width: 0; }
+    .fb-icon { width: 20px; height: 20px; border-radius: 4px; flex-shrink: 0; }
+    .fb-name { font-weight: 500; color: #fff; font-size: 0.95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .fb-right { display: flex; align-items: center; gap: 1rem; flex-shrink: 0; }
+    .fb-meta { text-align: right; font-size: 0.8rem; color: rgba(255,255,255,0.4); line-height: 1.4; }
+    .fb-status { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.3rem 0.7rem; border-radius: 6px; font-size: 0.75rem; font-weight: 500; }
+    .fb-status.up { background: rgba(34,197,94,0.1); color: #4ade80; }
+    .fb-status.down { background: rgba(239,68,68,0.1); color: #f87171; }
+    .fb-status .dot { width: 6px; height: 6px; border-radius: 50%; }
+    .fb-status.up .dot { background: #22c55e; }
+    .fb-status.down .dot { background: #ef4444; }
+    .fb-graphs { margin-top: 2rem; }
+    .fb-graphs h2 { font-size: 1.1rem; font-weight: 600; color: #fff; margin-bottom: 1rem; }
+    .fb-graph-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 1rem; }
+    .fb-graph-card { background: #0a0a0a; border: 1px solid rgba(255,255,255,0.04); border-radius: 12px; padding: 1rem; }
+    .fb-graph-card:hover { border-color: rgba(255,255,255,0.08); }
+    .fb-graph-card h3 { font-size: 0.8rem; font-weight: 500; color: rgba(255,255,255,0.5); margin-bottom: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .fb-graph-card img { width: 100%; border-radius: 8px; opacity: 0.9; }
+    .fb-graph-card img:hover { opacity: 1; }
+    @media (max-width: 480px) { .fb-graph-grid { grid-template-columns: 1fr; } .fb-right { flex-direction: column; align-items: flex-end; gap: 0.25rem; } }
   js: |
     (function(){
-      var CACHE_TTL = 300000;
-      var origFetch = window.fetch;
-      window.fetch = function(url, opts) {
-        if (typeof url === 'string' && url.indexOf('api.github.com') !== -1) {
-          var cacheKey = 'gh_cache_' + url;
-          var cached = localStorage.getItem(cacheKey);
-          if (cached) {
-            try {
-              var data = JSON.parse(cached);
-              if (Date.now() - data.ts < CACHE_TTL) {
-                return Promise.resolve(new Response(JSON.stringify(data.body), {
-                  status: 200,
-                  headers: {'Content-Type': 'application/json'}
-                }));
-              }
-            } catch(e) {}
-          }
-          return origFetch.call(window, url, opts).then(function(resp) {
-            if (resp.ok) {
-              var cloned = resp.clone();
-              cloned.json().then(function(json) {
-                try {
-                  localStorage.setItem(cacheKey, JSON.stringify({ts: Date.now(), body: json}));
-                } catch(e) {}
-              });
-            }
-            if (resp.status === 403 || resp.status === 429) {
-              if (cached) {
-                try {
-                  var stale = JSON.parse(cached);
-                  return new Response(JSON.stringify(stale.body), {
-                    status: 200,
-                    headers: {'Content-Type': 'application/json'}
-                  });
-                } catch(e) {}
-              }
-            }
-            return resp;
-          }).catch(function(err) {
-            if (cached) {
-              try {
-                var stale = JSON.parse(cached);
-                return new Response(JSON.stringify(stale.body), {
-                  status: 200,
-                  headers: {'Content-Type': 'application/json'}
-                });
-              } catch(e) {}
-            }
-            throw err;
-          });
+      var OWNER='Prosper-App',REPO='status';
+      var RAW='https://raw.githubusercontent.com/'+OWNER+'/'+REPO+'/master';
+      var CACHE_TTL=300000;
+      var origFetch=window.fetch;
+      window.fetch=function(url,opts){
+        if(typeof url==='string'&&url.indexOf('api.github.com')!==-1){
+          var ck='gh_cache_'+url;var c=localStorage.getItem(ck);
+          if(c){try{var d=JSON.parse(c);if(Date.now()-d.ts<CACHE_TTL)return Promise.resolve(new Response(JSON.stringify(d.body),{status:200,headers:{'Content-Type':'application/json'}}));}catch(e){}}
+          return origFetch.call(window,url,opts).then(function(r){
+            if(r.ok){var cl=r.clone();cl.json().then(function(j){try{localStorage.setItem(ck,JSON.stringify({ts:Date.now(),body:j}));}catch(e){}});}
+            if((r.status===403||r.status===429)&&c){try{var s=JSON.parse(c);return new Response(JSON.stringify(s.body),{status:200,headers:{'Content-Type':'application/json'}});}catch(e){}}
+            return r;
+          }).catch(function(err){if(c){try{var s=JSON.parse(c);return new Response(JSON.stringify(s.body),{status:200,headers:{'Content-Type':'application/json'}});}catch(e){}}throw err;});
         }
-        return origFetch.call(window, url, opts);
+        return origFetch.call(window,url,opts);
       };
-      if (window.location.pathname.indexOf('rate-limit') !== -1) {
-        window.location.href = '/';
+      function el(tag,cls,txt){var e=document.createElement(tag);if(cls)e.className=cls;if(txt)e.textContent=txt;return e;}
+      function addLabels(){
+        document.querySelectorAll('.tag.is-success').forEach(function(t){if(!t.dataset.lb){t.textContent='Operational';t.dataset.lb='1';}});
+        document.querySelectorAll('.tag.is-danger').forEach(function(t){if(!t.dataset.lb){t.textContent='Down';t.dataset.lb='1';}});
       }
+      new MutationObserver(function(){addLabels();}).observe(document.body,{childList:true,subtree:true});
+      function renderFallback(){
+        if(!document.querySelectorAll('.loading').length)return;
+        origFetch(RAW+'/history/summary.json').then(function(r){return r.json();}).then(function(sites){
+          var main=document.querySelector('main');if(!main)return;
+          while(main.firstChild)main.removeChild(main.firstChild);
+          var wrap=el('div','fallback-container');
+          var hdr=el('div','fallback-header');
+          hdr.appendChild(el('h1',null,'Prosper Status'));
+          var allUp=sites.every(function(s){return s.status==='up';});
+          var sum=el('div','fallback-summary');
+          sum.appendChild(el('div','fallback-dot '+(allUp?'up':'down')));
+          sum.appendChild(el('span',null,allUp?'All systems operational':'Some systems experiencing issues'));
+          hdr.appendChild(sum);
+          wrap.appendChild(hdr);
+          sites.forEach(function(s){
+            var card=el('div','fb-card');
+            var left=el('div','fb-left');
+            var icon=document.createElement('img');icon.className='fb-icon';icon.src=s.icon;icon.alt='';
+            left.appendChild(icon);left.appendChild(el('span','fb-name',s.name));
+            card.appendChild(left);
+            var right=el('div','fb-right');
+            var meta=el('div','fb-meta');
+            meta.appendChild(el('div',null,s.uptime+' uptime'));
+            meta.appendChild(el('div',null,s.time+' ms'));
+            right.appendChild(meta);
+            var isUp=s.status==='up';
+            var badge=el('div','fb-status '+(isUp?'up':'down'));
+            badge.appendChild(el('div','dot'));
+            badge.appendChild(document.createTextNode(isUp?'Operational':'Down'));
+            right.appendChild(badge);
+            card.appendChild(right);wrap.appendChild(card);
+          });
+          var gSec=el('div','fb-graphs');
+          gSec.appendChild(el('h2',null,'Response Time'));
+          var grid=el('div','fb-graph-grid');
+          sites.forEach(function(s){
+            var gc=el('div','fb-graph-card');
+            gc.appendChild(el('h3',null,s.name));
+            var img=document.createElement('img');
+            img.src=RAW+'/graphs/'+s.slug+'/response-time-week.png';
+            img.alt='Response time graph';
+            gc.appendChild(img);grid.appendChild(gc);
+          });
+          gSec.appendChild(grid);wrap.appendChild(gSec);
+          main.appendChild(wrap);
+        }).catch(function(){});
+      }
+      setTimeout(function(){if(document.querySelectorAll('.loading').length>0)renderFallback();},3000);
+      if(window.location.pathname.indexOf('rate-limit')!==-1)window.location.href='/';
     })();
 
 workflowSchedule:

--- a/history/prosper-admin-production.yml
+++ b/history/prosper-admin-production.yml
@@ -1,7 +1,7 @@
 url: https://admin.prosper.codes
 status: up
 code: 200
-responseTime: 303
-lastUpdated: 2026-03-04T06:28:01.622Z
+responseTime: 435
+lastUpdated: 2026-03-04T10:56:24.879Z
 startTime: 2026-03-04T05:23:39.018Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-admin-staging.yml
+++ b/history/prosper-admin-staging.yml
@@ -1,7 +1,7 @@
 url: https://admin-stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 589
-lastUpdated: 2026-03-04T06:28:00.676Z
+responseTime: 269
+lastUpdated: 2026-03-04T10:56:23.899Z
 startTime: 2026-03-04T05:23:37.390Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-production.yml
+++ b/history/prosper-api-production.yml
@@ -1,7 +1,7 @@
 url: https://api.prosper.codes/health
 status: up
 code: 200
-responseTime: 259
-lastUpdated: 2026-03-04T06:28:01.117Z
+responseTime: 167
+lastUpdated: 2026-03-04T10:56:24.256Z
 startTime: 2026-03-04T05:23:38.102Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-staging.yml
+++ b/history/prosper-api-staging.yml
@@ -1,7 +1,7 @@
 url: https://stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 201
-lastUpdated: 2026-03-04T06:27:59.896Z
+responseTime: 526
+lastUpdated: 2026-03-04T10:56:23.437Z
 startTime: 2026-03-04T05:23:36.459Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary
- **Status labels**: Upptime tags now show "Operational" / "Down" text via MutationObserver
- **Fallback renderer**: When GitHub API is rate limited (spinners visible after 3s), renders status page from `raw.githubusercontent.com/summary.json` — no rate limit
- **Graphs**: Loaded directly from raw.githubusercontent.com, always visible regardless of API status

## How it works
1. Page loads → Upptime tries GitHub API as usual
2. If API works: MutationObserver adds "Operational"/"Down" labels to tags
3. If API rate limited (spinners still showing after 3s): fallback kicks in
   - Fetches `summary.json` from raw.githubusercontent.com (CDN, no rate limit)
   - Builds status cards with service name, uptime %, response time, status badge
   - Loads graph images directly from raw.githubusercontent.com
   - `/rate-limit-exceeded` auto-redirects to `/` for fallback rendering

## Test plan
- [ ] Clear localStorage, visit status.prosper.codes — see full status with labels
- [ ] Exhaust rate limit (60 requests) — fallback renders with graphs
- [ ] Visit /rate-limit-exceeded — redirects to / with fallback content
- [ ] Status tags show "Operational" (green) or "Down" (red)