### PR TITLE
Fix JS crash: wait for document.body

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -226,7 +226,11 @@ status-website:
         document.querySelectorAll('.tag.is-success').forEach(function(t){if(!t.dataset.lb){t.textContent='Operational';t.dataset.lb='1';}});
         document.querySelectorAll('.tag.is-danger').forEach(function(t){if(!t.dataset.lb){t.textContent='Down';t.dataset.lb='1';}});
       }
-      new MutationObserver(function(){addLabels();}).observe(document.body,{childList:true,subtree:true});
+      function startObserver(){
+        if(document.body){new MutationObserver(function(){addLabels();}).observe(document.body,{childList:true,subtree:true});addLabels();}
+        else{document.addEventListener('DOMContentLoaded',function(){new MutationObserver(function(){addLabels();}).observe(document.body,{childList:true,subtree:true});addLabels();});}
+      }
+      startObserver();
       function renderFallback(){
         if(!document.querySelectorAll('.loading').length)return;
         origFetch(RAW+'/history/summary.json').then(function(r){return r.json();}).then(function(sites){
@@ -274,7 +278,8 @@ status-website:
           main.appendChild(wrap);
         }).catch(function(){});
       }
-      setTimeout(function(){if(document.querySelectorAll('.loading').length>0)renderFallback();},3000);
+      function scheduleFallback(){setTimeout(function(){if(document.querySelectorAll('.loading').length>0)renderFallback();},3000);}
+      if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',scheduleFallback);}else{scheduleFallback();}
       if(window.location.pathname.indexOf('rate-limit')!==-1)window.location.href='/';
     })();
 

--- a/history/prosper-admin-production.yml
+++ b/history/prosper-admin-production.yml
@@ -1,7 +1,7 @@
 url: https://admin.prosper.codes
 status: up
 code: 200
-responseTime: 447
-lastUpdated: 2026-03-04T10:58:00.109Z
+responseTime: 341
+lastUpdated: 2026-03-04T11:02:48.980Z
 startTime: 2026-03-04T05:23:39.018Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-admin-staging.yml
+++ b/history/prosper-admin-staging.yml
@@ -1,7 +1,7 @@
 url: https://admin-stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 337
-lastUpdated: 2026-03-04T10:57:59.020Z
+responseTime: 424
+lastUpdated: 2026-03-04T11:02:48.018Z
 startTime: 2026-03-04T05:23:37.390Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-production.yml
+++ b/history/prosper-api-production.yml
@@ -1,7 +1,7 @@
 url: https://api.prosper.codes/health
 status: up
 code: 200
-responseTime: 303
-lastUpdated: 2026-03-04T10:57:59.495Z
+responseTime: 291
+lastUpdated: 2026-03-04T11:02:48.475Z
 startTime: 2026-03-04T05:23:38.102Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-staging.yml
+++ b/history/prosper-api-staging.yml
@@ -1,7 +1,7 @@
 url: https://stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 491
-lastUpdated: 2026-03-04T10:57:58.511Z
+responseTime: 188
+lastUpdated: 2026-03-04T11:02:47.425Z
 startTime: 2026-03-04T05:23:36.459Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Fixes `MutationObserver` TypeError by wrapping in DOMContentLoaded guard. Script runs in `<head>` before body exists.