### PR TITLE
feat: enhance detail page with stats and response graph

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -287,6 +287,24 @@ status-website:
     .fb-status.up .dot { background: #22c55e; }
     .fb-status.down .dot { background: #ef4444; }
     @media (max-width: 480px) { .fb-card { flex-direction: column; align-items: flex-start; } .fb-right { flex-direction: row; width: 100%; justify-content: space-between; } }
+    .detail-container { max-width: 720px; margin: 0 auto; padding: 2rem 1rem; }
+    .detail-back { display: inline-flex; align-items: center; gap: 4px; font-size: 0.8rem; color: rgba(255,255,255,0.4) !important; margin-bottom: 1.5rem; transition: color 0.2s; }
+    .detail-back:hover { color: rgba(255,255,255,0.7) !important; }
+    .detail-header { display: flex; align-items: center; gap: 12px; margin-bottom: 1.5rem; }
+    .detail-icon { width: 28px; height: 28px; border-radius: 6px; }
+    .detail-title { font-size: 1.4rem !important; font-weight: 600 !important; color: #fff !important; margin: 0 !important; letter-spacing: -0.02em !important; }
+    .detail-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 2rem; }
+    .stat-card { background: #111; border: 1px solid rgba(255,255,255,0.08); border-radius: 10px; padding: 16px; text-align: center; }
+    .stat-value { font-size: 1.3rem; font-weight: 600; color: #fff; margin-bottom: 4px; }
+    .stat-label { font-size: 0.7rem; color: rgba(255,255,255,0.35); text-transform: uppercase; letter-spacing: 0.04em; }
+    .detail-section { margin-bottom: 2rem; }
+    .detail-section-title { font-size: 0.75rem !important; font-weight: 500 !important; color: rgba(255,255,255,0.4) !important; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px !important; }
+    .graph-tabs { display: flex; gap: 4px; margin-bottom: 12px; }
+    .graph-tab { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.06); color: rgba(255,255,255,0.5); border-radius: 6px; padding: 5px 12px; font-size: 0.7rem; font-weight: 500; cursor: pointer; transition: all 0.2s; font-family: inherit; }
+    .graph-tab:hover { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.8); }
+    .graph-tab.active { background: rgba(255,255,255,0.1); color: #fff; border-color: rgba(255,255,255,0.15); }
+    .detail-graph { width: 100%; border-radius: 10px; background: #111; border: 1px solid rgba(255,255,255,0.08); padding: 8px; }
+    @media (max-width: 600px) { .detail-stats { grid-template-columns: repeat(2, 1fr); } }
   js: |
     (function(){
       var OWNER='Prosper-App',REPO='status';
@@ -312,6 +330,9 @@ status-website:
 
       /* --- Inject badges, uptime bars, move banner to nav, hide empties --- */
       function enhance(){
+        /* Detail page */
+        enhanceDetail();
+
         /* Badges on article.link cards */
         document.querySelectorAll('article.link').forEach(function(a){
           if(a.dataset.enh)return;a.dataset.enh='1';
@@ -361,6 +382,75 @@ status-website:
         /* Detail page: tag labels */
         document.querySelectorAll('.tag.is-success').forEach(function(t){if(!t.dataset.lb){t.textContent='Operational';t.dataset.lb='1';}});
         document.querySelectorAll('.tag.is-danger').forEach(function(t){if(!t.dataset.lb){t.textContent='Down';t.dataset.lb='1';}});
+      }
+
+      /* --- Detail page enhancement --- */
+      function enhanceDetail(){
+        var path=window.location.pathname;
+        if(path.indexOf('/history/')===- 1)return;
+        if(document.querySelector('.detail-container'))return;
+        var slug=path.replace('/history/','').replace(/\/$/,'');
+        if(!slug)return;
+        origFetch(RAW+'/history/summary.json').then(function(r){return r.json();}).then(function(sites){
+          var site=sites.find(function(s){return s.slug===slug;});
+          if(!site)return;
+          var main=document.querySelector('main');
+          if(!main)return;
+          while(main.firstChild)main.removeChild(main.firstChild);
+          var wrap=el('div','detail-container');
+          var back=el('a','detail-back','\u2190 All services');
+          back.href='/';
+          wrap.appendChild(back);
+          var hdr=el('div','detail-header');
+          var icon=document.createElement('img');icon.className='detail-icon';icon.src=site.icon;icon.alt='';
+          hdr.appendChild(icon);
+          var title=el('h1','detail-title',site.name);
+          var isUp=site.status==='up';
+          var badge=el('span','status-badge '+(isUp?'badge-up':'badge-down'));
+          badge.appendChild(el('span','badge-dot'));
+          badge.appendChild(document.createTextNode(isUp?'Operational':'Down'));
+          title.appendChild(badge);
+          hdr.appendChild(title);
+          wrap.appendChild(hdr);
+          var stats=el('div','detail-stats');
+          [{l:'Uptime (24h)',v:site.uptimeDay},{l:'Uptime (7d)',v:site.uptimeWeek},{l:'Uptime (30d)',v:site.uptimeMonth},{l:'Avg Response',v:site.time+'ms'}].forEach(function(s){
+            var card=el('div','stat-card');
+            card.appendChild(el('div','stat-value',s.v));
+            card.appendChild(el('div','stat-label',s.l));
+            stats.appendChild(card);
+          });
+          wrap.appendChild(stats);
+          var barSec=el('div','detail-section');
+          barSec.appendChild(el('h2','detail-section-title','Uptime (30 days)'));
+          var bar=el('div','uptime-bar');
+          for(var i=0;i<30;i++)bar.appendChild(el('div','bar-seg '+(isUp?'up':'unknown')));
+          barSec.appendChild(bar);
+          var lbl=el('div','bar-label');
+          lbl.appendChild(el('span',null,'30 days ago'));
+          lbl.appendChild(el('span',null,'Today'));
+          barSec.appendChild(lbl);
+          wrap.appendChild(barSec);
+          var gSec=el('div','detail-section');
+          gSec.appendChild(el('h2','detail-section-title','Response Time'));
+          var tabs=el('div','graph-tabs');
+          var gImg=document.createElement('img');
+          gImg.className='detail-graph';
+          gImg.src=RAW+'/graphs/'+slug+'/response-time-week.png';
+          gImg.alt='Response time';
+          [{k:'day',l:'24h'},{k:'week',l:'7d'},{k:'month',l:'30d'},{k:'year',l:'1y'}].forEach(function(p){
+            var tab=el('button','graph-tab'+(p.k==='week'?' active':''),p.l);
+            tab.addEventListener('click',function(){
+              tabs.querySelectorAll('.graph-tab').forEach(function(t){t.classList.remove('active');});
+              tab.classList.add('active');
+              gImg.src=RAW+'/graphs/'+slug+'/response-time-'+p.k+'.png';
+            });
+            tabs.appendChild(tab);
+          });
+          gSec.appendChild(tabs);
+          gSec.appendChild(gImg);
+          wrap.appendChild(gSec);
+          main.appendChild(wrap);
+        }).catch(function(){});
       }
 
       /* --- Start MutationObserver safely --- */

--- a/history/prosper-admin-production.yml
+++ b/history/prosper-admin-production.yml
@@ -1,7 +1,7 @@
 url: https://admin.prosper.codes
 status: up
 code: 200
-responseTime: 865
-lastUpdated: 2026-03-04T11:33:36.172Z
+responseTime: 279
+lastUpdated: 2026-03-04T11:42:45.774Z
 startTime: 2026-03-04T05:23:39.018Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-admin-staging.yml
+++ b/history/prosper-admin-staging.yml
@@ -1,7 +1,7 @@
 url: https://admin-stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 128
-lastUpdated: 2026-03-04T11:33:34.044Z
+responseTime: 256
+lastUpdated: 2026-03-04T11:42:44.585Z
 startTime: 2026-03-04T05:23:37.390Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-production.yml
+++ b/history/prosper-api-production.yml
@@ -1,7 +1,7 @@
 url: https://api.prosper.codes/health
 status: up
 code: 200
-responseTime: 896
-lastUpdated: 2026-03-04T11:33:35.123Z
+responseTime: 524
+lastUpdated: 2026-03-04T11:42:45.302Z
 startTime: 2026-03-04T05:23:38.102Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-staging.yml
+++ b/history/prosper-api-staging.yml
@@ -1,7 +1,7 @@
 url: https://stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 518
-lastUpdated: 2026-03-04T11:33:33.728Z
+responseTime: 445
+lastUpdated: 2026-03-04T11:42:44.131Z
 startTime: 2026-03-04T05:23:36.459Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary
- Replace empty detail page with rich service view
- Add back navigation link ("← All services")
- Show service name with icon and status badge (Operational/Down)
- Display 4 stat cards: Uptime 24h, 7d, 30d + Avg Response time
- Add 30-segment uptime bar matching the main page style
- Add response time graph with period tabs (24h / 7d / 30d / 1y)
- All data fetched from raw.githubusercontent.com (no API rate limits)

## Test plan
- [ ] Click a service card on main page → detail page renders with stats
- [ ] Verify all 4 stat cards show correct values
- [ ] Click period tabs (24h/7d/30d/1y) → graph image updates
- [ ] Click "← All services" → navigates back to main page
- [ ] Test on mobile viewport (stat cards should go 2x2)