### PR TITLE
fix: force full page reload on back link

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -400,6 +400,7 @@ status-website:
           var wrap=el('div','detail-container');
           var back=el('a','detail-back','\u2190 All services');
           back.href='/';
+          back.addEventListener('click',function(e){e.preventDefault();window.location.href='/';});
           wrap.appendChild(back);
           var hdr=el('div','detail-header');
           var icon=document.createElement('img');icon.className='detail-icon';icon.src=site.icon;icon.alt='';


### PR DESCRIPTION
## Summary
- Fix "← All services" back link on detail pages not working
- Sapper intercepts anchor clicks for client-side routing, bypassing our JS-injected content
- Added `preventDefault` + `window.location.href` to force a full page reload

## Test plan
- [ ] Open a service detail page → click "← All services" → main page loads correctly