### PR TITLE
fix: real-time data and increased check frequency

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -17,7 +17,7 @@
 name: Summary CI
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "*/5 * * * *"
   repository_dispatch:
     types: [summary]
   workflow_dispatch:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -17,7 +17,7 @@
 name: Uptime CI
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/3 * * * *"
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -408,9 +408,22 @@ status-website:
         if(document.querySelector('.detail-container'))return;
         var slug=path.replace('/history/','').replace(/\/$/,'');
         if(!slug)return;
-        origFetch(RAW+'/history/summary.json').then(function(r){return r.json();}).then(function(sites){
+        /* Fetch both summary.json (stats) and live history yml (current status) */
+        Promise.all([
+          origFetch(RAW+'/history/summary.json').then(function(r){return r.json();}),
+          origFetch(RAW+'/history/'+slug+'.yml').then(function(r){return r.text();}).catch(function(){return '';})
+        ]).then(function(results){
+          var sites=results[0];var ymlText=results[1];
+          /* Parse live status from yml */
+          var liveStatus=null;
+          if(ymlText){
+            var m=ymlText.match(/status:\s*(\w+)/);
+            if(m)liveStatus=m[1];
+          }
           var site=sites.find(function(s){return s.slug===slug;});
           if(!site)return;
+          /* Override status with live data if available */
+          if(liveStatus)site.status=liveStatus;
           var main=document.querySelector('main');
           if(!main)return;
           while(main.firstChild)main.removeChild(main.firstChild);
@@ -527,11 +540,11 @@ status-website:
     })();
 
 workflowSchedule:
-  uptime: "*/5 * * * *"
+  uptime: "*/3 * * * *"
   responseTime: "0 23 * * *"
   graphs: "0 0 * * *"
   staticSite: "0 1 * * *"
-  summary: "0 0 * * *"
+  summary: "*/5 * * * *"
   updateTemplate: "0 0 * * *"
   updates: "0 3 * * *"
 

--- a/history/prosper-admin-production.yml
+++ b/history/prosper-admin-production.yml
@@ -1,7 +1,7 @@
 url: https://admin.prosper.codes
 status: up
 code: 200
-responseTime: 238
-lastUpdated: 2026-03-08T13:50:18.175Z
+responseTime: 593
+lastUpdated: 2026-03-08T14:04:45.198Z
 startTime: 2026-03-04T05:23:39.018Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-admin-staging.yml
+++ b/history/prosper-admin-staging.yml
@@ -1,7 +1,7 @@
 url: https://admin-stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 167
-lastUpdated: 2026-03-08T13:50:17.079Z
+responseTime: 559
+lastUpdated: 2026-03-08T14:04:43.792Z
 startTime: 2026-03-04T05:23:37.390Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-production.yml
+++ b/history/prosper-api-production.yml
@@ -1,7 +1,7 @@
 url: https://api.prosper.codes/health
 status: up
 code: 200
-responseTime: 479
-lastUpdated: 2026-03-08T13:50:17.747Z
+responseTime: 493
+lastUpdated: 2026-03-08T14:04:44.444Z
 startTime: 2026-03-04T05:23:38.102Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-staging.yml
+++ b/history/prosper-api-staging.yml
@@ -1,7 +1,7 @@
 url: https://stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 312
-lastUpdated: 2026-03-08T13:50:16.720Z
+responseTime: 427
+lastUpdated: 2026-03-08T14:04:43.066Z
 startTime: 2026-03-04T05:23:36.459Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Problem
- `summary.json` updated only once daily (00:00 UTC) — detail pages, uptime bars, and fallback showed up to 24h stale data
- Uptime checks every 5 min, but GitHub Actions can handle ~3 min intervals

## Changes
- **Uptime CI**: `*/5` → `*/3` (check every ~3 minutes)
- **Summary CI**: `0 0 * * *` → `*/5 * * * *` (update summary.json every 5 minutes, keeping it fresh)
- **Detail page**: Now fetches both `summary.json` (for stats) AND live `history/{slug}.yml` (for current status), overriding with real-time data

## Data freshness after fix
| Component | Before | After |
|-----------|--------|-------|
| Main page (Sapper) | ~5 min | ~3 min |
| Detail page status | **24h** | **~3-5 min** |
| Uptime bars (dailyMinutesDown) | **24h** | **~5 min** |
| Fallback renderer | **24h** | **~5 min** |

## Test plan
- [ ] Verify Uptime CI runs approximately every 3 minutes
- [ ] Verify Summary CI runs every 5 minutes (check commits)
- [ ] Open detail page — status badge should match main page
- [ ] Wait for workflows to regenerate after merge