### PR TITLE
fix: equalize card heights in live status grid

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -183,18 +183,15 @@ status-website:
       display: grid !important;
       grid-template-columns: repeat(2, 1fr) !important;
       gap: 12px !important;
+      align-items: stretch !important;
     }
-    .live-status .column {
-      display: flex !important;
-    }
-    article.link {
+    .live-status article.link {
       padding: 16px 20px !important;
       border-radius: 12px !important;
       background: #111 !important;
       border: 1px solid rgba(255,255,255,0.08) !important;
-      display: flex !important;
-      flex-direction: column !important;
-      flex: 1 !important;
+      height: 100% !important;
+      box-sizing: border-box !important;
     }
     article.link:hover {
       border-color: rgba(255,255,255,0.14) !important;

--- a/history/prosper-admin-production.yml
+++ b/history/prosper-admin-production.yml
@@ -1,7 +1,7 @@
 url: https://admin.prosper.codes
 status: up
 code: 200
-responseTime: 365
-lastUpdated: 2026-04-01T12:14:06.582Z
+responseTime: 381
+lastUpdated: 2026-04-01T12:25:29.351Z
 startTime: 2026-03-04T05:23:39.018Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-admin-staging.yml
+++ b/history/prosper-admin-staging.yml
@@ -1,7 +1,7 @@
 url: https://admin-stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 462
-lastUpdated: 2026-04-01T12:14:05.603Z
+responseTime: 488
+lastUpdated: 2026-04-01T12:25:28.263Z
 startTime: 2026-03-04T05:23:37.390Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-production.yml
+++ b/history/prosper-api-production.yml
@@ -1,7 +1,7 @@
 url: https://api.prosper.codes/health
 status: up
 code: 200
-responseTime: 280
-lastUpdated: 2026-04-01T12:14:06.050Z
+responseTime: 352
+lastUpdated: 2026-04-01T12:25:28.792Z
 startTime: 2026-03-04T05:23:38.102Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/prosper-api-staging.yml
+++ b/history/prosper-api-staging.yml
@@ -1,7 +1,7 @@
 url: https://stage.prosper.codes/health
 status: up
 code: 200
-responseTime: 406
-lastUpdated: 2026-04-01T12:14:04.972Z
+responseTime: 224
+lastUpdated: 2026-04-01T12:25:27.594Z
 startTime: 2026-03-04T05:23:36.459Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary
- Add `align-items: stretch` on `.live-status` grid and `height: 100%; box-sizing: border-box` on cards
- Ensures all cards in each row match the tallest card's height

Supersedes #19

## Test plan
- [x] Verified in browser — all 4 cards now 158px (equal height)
- [ ] Check responsive layout on mobile (single column)