### PR TITLE
fix: reset margin-top on grid cards for row alignment

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -191,6 +191,7 @@ status-website:
       background: #111 !important;
       border: 1px solid rgba(255,255,255,0.08) !important;
       height: 100% !important;
+      margin-top: 0 !important;
       box-sizing: border-box !important;
     }
     article.link:hover {


### PR DESCRIPTION
## Summary
- Reset `margin-top: 0` on `.live-status article.link` to fix misaligned cards
- Svelte's adjacent sibling selector adds 8px margin-top which shifts the second column down relative to the first

## Test plan
- [x] Verified in browser — both cards in each row now share the same top position (0px and 162px)