### PR TITLE
fix(ci): serialize main-pushing workflows to avoid push race

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -21,6 +21,9 @@ on:
   repository_dispatch:
     types: [summary]
   workflow_dispatch:
+concurrency:
+  group: write-main
+  cancel-in-progress: false
 jobs:
   release:
     name: Generate README

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -21,6 +21,9 @@ on:
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:
+concurrency:
+  group: write-main
+  cancel-in-progress: false
 jobs:
   release:
     name: Check status


### PR DESCRIPTION
## Summary

- `Summary CI` (every 5 min) and `Uptime CI` (every 3 min) push to `main` from parallel runners. Schedules collide on minutes 0/15/30/45 → second push fails with `[rejected] main -> main (fetch first)`.
- Recent example: [run 25616266935](https://github.com/Prosper-App/status/actions/runs/25616266935). Failure rate ~2% but failures cluster (e.g. 7 in one hour on 2026-04-27).
- Adds shared `concurrency` group `write-main` with `cancel-in-progress: false` to both workflows so runs **queue** instead of racing. No data is lost.

## Caveats

- These workflow files are auto-generated by the Upptime template (regenerated on each `update-template` run, e.g. v1.41.0 → v1.41.3). The `concurrency` block may be wiped on next template upgrade and need to be re-applied. Upptime config (`.upptimerc.yml`) currently has no native option for this.

## Test plan

- [ ] Workflow files parse — confirmed by GitHub Actions running them after merge
- [ ] No `[rejected] main -> main` failures in `Summary CI` / `Uptime CI` over the next 24-48h (compare to baseline ~2% failure rate)
- [ ] Queued runs visible in Actions UI when both workflows fire on overlapping minutes (0/15/30/45)